### PR TITLE
Front-End Stalemate

### DIFF
--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -23,6 +23,12 @@ class GamesController < ApplicationController
     redirect_to game_path(@game)
   end
 
+  def stalemate
+    @game = current_game
+    @game.destroy
+    redirect_to game_path, alert: 'Stalemate. Game ends in a draw.'
+  end
+
   def forfeit
     @game = current_game
     @game.forfeit(current_user)

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -40,11 +40,9 @@ class Game < ActiveRecord::Base
   end
 
   def stalemate?
-    # get king
     color = active_player == white_player ? 0 : 1
-    king = pieces.find_by(type: 'King', color: color)
-
-    # check moves
+    king = pieces.find_by(type: 'King', color: color) # gets king
+    # checks moves
     return false if king_in_check?(king)
     return true unless king_has_valid_move?(king)
     false
@@ -58,26 +56,15 @@ class Game < ActiveRecord::Base
     false
   end
 
-  def forfeit(current_user)
-    if current_user == white_player
-      white_player.increment(:losses)
-      black_player.increment(:wins)
-      winning_player = black_player
-    else
-      white_player.increment(:wins)
-      black_player.increment(:losses)
-      winning_player = white_player
-    end
+  def forfeit(user)
+    user.increment(:losses)
+    other_user(user).increment(:wins)
+    winning_player = other_user(user)
     update!(winning_player: winning_player)
   end
 
   def assign_turn(player)
-    active_player = if player == white_player
-                      white_player
-                    else
-                      black_player
-                    end
-    update!(active_player: active_player)
+    update!(active_player: player)
   end
 
   private
@@ -99,5 +86,9 @@ class Game < ActiveRecord::Base
 
   def opposite_color(color) # returns the opposite color
     color == 'white' ? 'black' : 'white'
+  end
+
+  def other_user(user) # returns the other user
+    user == white_player ? black_player : white_player
   end
 end

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -35,6 +35,12 @@
   <% end %>
 <% end %>
 
+<% if (@game.winning_player == nil && @game.white_player_id && @game.black_player_id)  && @game.pieces != []%>
+  <% if @game.stalemate? %>
+    <%= redirect_to stalemate_game_path(@game), method: :put %>
+  <% end %>
+<% end %>
+
 <div class="grass valign-wrapper green lighten-3">
   <div class="card-panel frame">
     <div class="spacing">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
   resources :games, only: [:new, :create, :show, :update] do
     member do
       put :forfeit
+      put :stalemate
     end
     resources :pieces, only: [:show, :update]
   end

--- a/spec/features/forfeit_spec.rb
+++ b/spec/features/forfeit_spec.rb
@@ -7,6 +7,9 @@ RSpec.feature 'forfeit a game' do
 
   context 'when forfeitting' do
     it 'allows user to quit' do
+      FactoryGirl.create(:king, x_position: 0, y_position: 0, color: 'black', game: game)
+      FactoryGirl.create(:king, x_position: 3, y_position: 2, color: 'white', game: game)
+      FactoryGirl.create(:queen, x_position: 2, y_position: 3, color: 'white', game: game)
       login_as(user1)
       visit game_path(game)
       find_link('Forfeit')

--- a/spec/features/join_game_spec.rb
+++ b/spec/features/join_game_spec.rb
@@ -9,7 +9,7 @@ RSpec.feature 'join a game' do
     it 'allows user to join' do
       login_as(user2, scope: :user)
       visit game_path(game)
-
+      game.populate_board!
       find_link('Join Game')
       click_link('Join Game')
 

--- a/spec/features/stalemate_spec.rb
+++ b/spec/features/stalemate_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+RSpec.feature 'stalemate' do
+  let(:user1) { FactoryGirl.create(:user) }
+  let(:user2) { FactoryGirl.create(:user) }
+  let(:game) { FactoryGirl.create(:game, white_player_id: user1.id, black_player_id: user2.id) }
+
+  context 'when in stalemate' do
+    it 'should end game in draw and alert the players' do
+      login_as(user2, scope: :user)
+      visit game_path(game)
+      FactoryGirl.create(:king, x_position: 0, y_position: 0, color: 'black', game: game)
+      FactoryGirl.create(:king, x_position: 2, y_position: 1, color: 'white', game: game)
+      FactoryGirl.create(:queen, x_position: 1, y_position: 2, color: 'white', game: game)
+
+      game.reload
+      game.stalemate?
+      expect('Stalemate. Game ends in a Draw').to be_present
+    end
+  end
+
+  context 'when not in stalemate' do
+    it 'should do nothing' do
+      login_as(user1, scope: :user)
+      visit game_path(game)
+      FactoryGirl.create(:king, x_position: 0, y_position: 0, color: 'black', game: game)
+      FactoryGirl.create(:king, x_position: 3, y_position: 2, color: 'white', game: game)
+      FactoryGirl.create(:queen, x_position: 2, y_position: 3, color: 'white', game: game)
+
+      game.stalemate?
+      expect(page).to_not have_content 'Stalemate. Game ends in a Draw'
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -5,6 +5,7 @@ require File.expand_path('../../config/environment', __FILE__)
 abort('The Rails environment is running in production mode!') if Rails.env.production?
 require 'spec_helper'
 require 'rspec/rails'
+require 'pry'
 # Add additional requires below this line. Rails is not loaded until this point!
 
 # Requires supporting ruby files with custom matchers and macros, etc, in

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -32,7 +32,6 @@ RSpec.configure do |config|
   end
 
   require 'capybara/rspec'
-
   # rspec-mocks config goes here. You can use an alternate test double
   # library (such as bogus or mocha) by changing the `mock_with` option here.
   config.mock_with :rspec do |mocks|


### PR DESCRIPTION
- adds stalemate method to games controller
   - destroys game, alerts to user the game ended in draw
- revises forfeit by adding `other(user)` method
- removes redudancy in `assign_turn(player)`
 Adds: 
    -  check for stalemate in show.html.erb
    -  feature test for stalemate
    -  `pry` to rspec tests
    - `:stalemate` to routes
    - pieces to the board in certain rspec tests